### PR TITLE
add ro32 highlights

### DIFF
--- a/highlights/ro32.md
+++ b/highlights/ro32.md
@@ -1,0 +1,47 @@
+The intense fight between **Philippines** and **Japan** resulted in the first tiebreaker of 4 Digit MWC 2023. Let's take a look and analyze the strategy of both teams, and how the outcome was the essence of the tournaments.
+
+## Pre-Match Analysis
+
+According to qualifiers statistics, **Japan** players has the significant disadvantages for Hybrid in Early Game and LN in Late Game. For the consistency wise, the scores could be fluctuated. Meanwhile for the SV Qualifiers, the score were 30k Differences which was significance from the human observation.
+
+The analysis indicated the intense match in other skillsets, meanwhile **Japan** chance of obtaining the point from LN and Hybrid is difficult.
+
+## Protects and Bans
+
+Philippines protected **LN3 - Time Traveler**, one of those release-oriented maps selected in this round. This map is focused on the 1/4 Releases, and some more releases with the light rhythms. The lighter rhythms imply more difficulty in maintaining the accuracy in early game. It could be the map which the result is more deterministic, and more focused on the difference of 200s, or even misses.
+
+Japan protected **SV2 - Sweet Dreams**, knowing that Philippines would ban one of the SVs and some high difference of the qualifiers scores. They decided to protect one of the frequent pick in SVs which is this map. It is more focused on the ability to read and react to the main motif of the song which is the usual patterns we can see in various SV maps.
+
+Philippines banned **SV1 - Progress**, due to it is the Japan's strength and the rhythm complexity which created the difficulty to maintain the accuracy in the map. Plus some memorization twists which.
+
+Japan banned **LN2 - FREE**, due to its repetition and difficulty in *early game density* and jumpjacks in the transitions. Which could cause the struggles of maintaining the accuracy or combo throughout the map without enough ability to release.
+
+## Picks
+
+We started off the pick with **Japan**'s protect, which is **Sweet Dreams**, the SV map focused on consistency and more stable rhythms. **iiderp**, one of the Philippines player decided to play with a mod Fade-In which required the decreasing of the scroll speed by approximately half. They got 2 misses in the beginning of the song and without any further misses from anyone. **Japan** was successful on taking their own first pick with double 997k from their team members. 
+
+**Philippines** then responded with **Super Haraguro Pop**, a hybrid map which is focused more on the accuracy side and 1/4 Releases, with the additional difficulty from the release graces LNs in some parts. Despite the statistical difference in the hybrid qualifiers, **Japan** managed to get close to **Philippines** with 2k points difference. Unfortunately they were not able to steal the pick from them.
+
+**Japan** had the choice of picking the index streams like **Heavenly Spores**, the 225bpm streams. It was the MA ratio vs. 200 battle but the MA ratio won the battle. **Philippines** were able to obtain the triple SS, but that was not enough for them to win the pick against **Japan**. However, this pick was resulted in the really close 589 points difference.
+
+**Philippines** then put an UNO Reverse Card with another LN pick, **Mirareru Mirror**. This map is one of another release map, which focused a lot on 1/2 releases, consistency and 3 columns release. It was predicted to be the significant advantage for **Philippines** but the difference were close to 7.4k points with more 200 counts from **Philippines**. However, they were able to secure the win for this pick.
+
+Seeing the intensity of the previous **Japan**'s pick, they decided to continue with more tricky map, **HAELEQUIN**. The map contained **Minijacks** and more significant **Index Bursts** and **Trills**. Hence this point was more indicated by the miss count. The misses were all on the **Philippines** side with the total of 3 misses from the 2nd and 3rd Players of the map. Meanwhile **Japan** had the total of 4x200 without any misses. They got a win with the significant point difference, approximately 30k points.
+
+Here comes the **Philippines**' protect, **Time Traveler**. The LN Mixed, with more oriented of the Releases. Surprisingly, there were no misses from anyone for this pick and the pick tend to be more of the accuracy battle. It was successful as a plan for **Philippines** as the 3rd player of **Japan** struggled to maintain the consistency for this map which resulted in their 19x200 final score. It was a tie between **Philippines** and **Japan** again after this pick.
+
+The result was 3-3, **Japan** had 3 remaining rice picks while **Philippines** had an only hybrid pick, Hotel Moonside. However, they had only a chance to pick their best strategy, and for **Philippines**, it was just a hit or miss for their pick as the hybrid map focused more on control and consistency.  
+
+**Japan** decided to pull out another consistency map, **Bad for me**, with the belief that it will be **Good for Them**. This heavy amen break remix with J-pop song were crafted into a Jumpstream/Consistency and *trills* oriented map by a well-known player, Myuka. All three players from both teams could maintain their accuracy and following each other in terms of 200 counts, resulted in a tie of 200 counts between the third player, and Double SS from both teams. The point were decided in the MA Ratio, which **Japan** performed better with 1.4k difference.
+
+The last pick from **Philippines**, it was either an entire match or the last hope of them. They decided to go with *technically* the only option for them, **Hotel Moonside (1.2 Rate)**. The map is hybrid with the difficulty of LN Control at the beginning, focusing a lot on consistency and ability to maintain the accuracy throughout the map. **Philippines** performed the top throughout this map, secured a point and brought the match to a tiebreaker.
+
+The tiebreaker was placed on the table, commemorate the **New Era** of this tournament. The map started with the slight advantages from **Philippines** in the first drop where it was more LN Oriented. Then we approached the Jumpgluts as the intermission between the drops. iiderp got the first miss of the map, however the lead was still explicitly high throughout the technical hybrid portion of the map due to the accuracy advantage, then we approached the break.
+
+After the break, as the pattern started rising up the intensity that the chordjacks were introduced in 128bpm range, **Japan** had the additional misses from **yakik** and **Philippines** got the second miss from **Frossno**. The merit from the accuracy advantage from the first half was still yield the result that **Philippines** was still on the lead. We then reached the last climax of the song, which introduced the 1/8 stream switching with chordjacks throughout the rest of the maps.
+
+The difference were more significant as the map progressed, it was clearly the victory for the **Philippines** when the song reached towards the end. They will advance through the winner's brackets, and **Japan** will have one more chance in the loser's brackets.
+
+## Match Summary
+
+This match was the perfect example of the battle between SV, Rice skillsets and LN, Hybrid skillsets. The picks that both teams picked were secured by them, and the match were intense even though none of them decided to take a risk out of their area of profession yet. Since the tiebreaker requires the skill of LNs, the Philippines secured the advantages and pursue the win over Japan in this round.

--- a/opinions/week2.md
+++ b/opinions/week2.md
@@ -1,5 +1,3 @@
-# percy_grammaredit
-
 # Percy Long Notes (LNs)
 
 I’m sure everyone who has been around the mania scene for more than a few months has heard of Percy, and may even be using it. No, it is not a person. You may have also heard players call them “Percys”, “cut LN”, “Short LN”, “Cheat LN”, and many more. Hopefully by the end of all this you will have a clearer idea of what Percy LNs are and the impact they have on gameplay.


### PR DESCRIPTION
- Article Type: highlights
- Header: Philippines vs. Japan: The initialization of the essence
- Subtitle: The tiebreaker is undeniably the essence of all tournaments, and it has been provoked for the first time in the arena between Philippines and Japan. We will dive through the analysis and the match progression of this intense show!
- Author(s): IndexError
